### PR TITLE
temp limits, sleep, PID

### DIFF
--- a/Firmware/smog-alado/platformio.ini
+++ b/Firmware/smog-alado/platformio.ini
@@ -16,7 +16,8 @@ board_build.filesystem = littlefs
 upload_protocol = espota
 monitor_speed = 115200
 ;upload_speed = 1024000
-upload_port = 192.168.5.152
+;upload_port = 192.168.5.152
+upload_port = 10.0.0.179
 lib_deps = 
 	Wire
 	SPI

--- a/Firmware/smog-alado/src/components/THERMISTOR/features/read_temp_thermistor.h
+++ b/Firmware/smog-alado/src/components/THERMISTOR/features/read_temp_thermistor.h
@@ -13,8 +13,8 @@ double calculate_resistance()
   {
     adcRaw = ads.readADC_SingleEnded(0);
     adcVoltage = ads.computeVolts(adcRaw);
-    if (adcRaw < 1000)
-      return 120000;
+    //if (adcRaw < 1000)
+    //  return 120000;
   }
   else
   {
@@ -24,23 +24,28 @@ double calculate_resistance()
   resistor = (3.3 / (adcVoltage)) * PULLDOWN - PULLDOWN;
   if (resistor < 150)
     resistor = 150;
-  if (resistor > 120000)
-    resistor = 120000;
+  //if (resistor > 120000)
+  //  resistor = 120000;
   return resistor;
 }
 
 double steinhart(double thermistor)
 {
+  NTC = 100;
 
-  //  NTC 3950 10k
-  //  const static double  a = 0.0011260101763638105;
-  //  const static double  b = 0.00023990205585764816;
-  //  const static double  c = -3.1848655700239605e-8;
+  if (NTC = 100)  //NTC 3950 100k
+  {
+    a = 0.0008002314855002526;
+    b = 0.0001989545566222665;
+    c = 1.7249962319615102e-7;
+  }
 
-  //  NTC 3950 100k
-  const static double a = 0.0008002314855002526;
-  const static double b = 0.0001989545566222665;
-  const static double c = 1.7249962319615102e-7;
+  if (NTC = 10)  //NTC 3950 10k
+  {
+    a = 0.0011260101763638105;
+    b = 0.00023990205585764816;
+    c = -3.1848655700239605e-8;
+  }
 
   // Utilizes the Steinhart-Hart Thermistor Equation:
   // Temperature in Kelvin = 1 / {A + B[ln(R)] + C[ln(R)]^3}

--- a/Firmware/smog-alado/src/main.cpp
+++ b/Firmware/smog-alado/src/main.cpp
@@ -57,7 +57,10 @@ void loop()
 {
   ArduinoOTA.handle();
 
-  myPID.Compute();
+  if (tempGoal > 0) 
+  {
+    myPID.Compute();
+  }
 
   buttonPress(buttonPin);
 
@@ -79,7 +82,7 @@ void loop()
       updateDisplay();
   }
 
-  if (idleTimer > (TIME_TO_SLEEP)) // sleep after 10 minutes
+  if ((idleTimer > (TIME_TO_SLEEP)) && (tempGoal > 50) ) // sleep after 10 minutes
   {
     sleepRoutine();
   }

--- a/Firmware/smog-alado/src/shared/variables.h
+++ b/Firmware/smog-alado/src/shared/variables.h
@@ -30,6 +30,8 @@ uint16_t adcFiltered = 1000;
 double Kp = 1, Ki = 1, Kd = 1;
 bool tuning = false;
 
+static double NTC, a, b, c;
+
 PID myPID(&heaterTemperature, &power, &tempGoal, Kp, Ki, Kd, P_ON_M, DIRECT);
 
 //* Timers for ilusion of threads


### PR DESCRIPTION
Removed low temperature reading limits. Set new condition of minimum temperature goal to activate sleep, and temperature goal must be higher than zero to calculate PID. Better selection for thermistor type between 10k or 100k.